### PR TITLE
evm fix es save token_id long to keyword

### DIFF
--- a/db/evm/mapping.go
+++ b/db/evm/mapping.go
@@ -35,7 +35,7 @@ const TokenMapping = `{
     "mappings":{
         "properties":{
             "token_id":{
-                "type":"long"
+                "type":"keyword"
             },
             "owner":{
                 "type":"keyword"
@@ -75,7 +75,7 @@ const EVMTransferMapping = `{
     "mappings":{
         "properties":{
             "token_id":{
-                "type":"long"
+                "type":"keyword"
             },
             "from":{
                 "type":"keyword"


### PR DESCRIPTION
修复了token_id为大数字的时候，http传给前端时，会超出范围丢失精度的问题